### PR TITLE
handle background build as a library not a webapp

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,13 +2,19 @@ import { defineConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { replaceCodePlugin } from "vite-plugin-replace";
 import { config as configDotenv } from "dotenv";
+import { resolve } from "path";
 
+// infer which code we are building. We can choose between app, background and popup
 const buildScript = process.env.npm_lifecycle_event || "";
 
 const app = buildScript.includes(":") ? buildScript.split(":")[1] : "app";
 
+// if building background, treat it as a library, not a web app
+const isLibrary = app === "background";
+
 const buildConfig = {
   rootHtml: `./${app}.html`,
+  entryFileLib: `.src/${app}/${app}.ts`,
   entryFileNames: `${app}/${app}.js`,
   assetFileNames: `${app}/${app}.[ext]`,
 };
@@ -18,7 +24,8 @@ configDotenv();
 
 export default defineConfig({
   plugins: [
-    svelte(),
+    // Only use svelte if not a library
+    !isLibrary && svelte(),
     replaceCodePlugin({
       replacements: [
         {
@@ -37,6 +44,10 @@ export default defineConfig({
     }),
   ],
   build: {
+    lib: isLibrary && {
+      entry: resolve(__dirname, buildConfig.entryFileLib),
+      name: app,
+    },
     rollupOptions: {
       input: { app: buildConfig.rootHtml },
       output: {


### PR DESCRIPTION
Fixes document is not defined error when loading in chrome using manifest v3.

This is a workaround. At some point we need to fix how we bundle the three tings (app, popup and background script) together in a nice way. For now it works :)